### PR TITLE
Add npmCommand parameter to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,4 +74,5 @@ jobs:
           releaseBody: "See the assets to download this version and install."
           releaseDraft: true
           prerelease: false
+          npmCommand: npm
           args: ${{ matrix.args }}


### PR DESCRIPTION
- Introduced npmCommand parameter in the release.yml to explicitly specify the npm command.
- This change enhances flexibility in the release process and aligns with the recent updates to use npm consistently across workflows.