### PR TITLE
Fix release workflow: Use correct tauriScript parameter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: 'npm'
+          cache: "npm"
 
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -43,7 +43,7 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: './src-tauri -> target'
+          workspaces: "./src-tauri -> target"
 
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
@@ -74,5 +74,6 @@ jobs:
           releaseBody: "See the assets to download this version and install."
           releaseDraft: true
           prerelease: false
-          npmCommand: npm
+          tauriScript: npm run tauri
+          includeUpdaterJson: true
           args: ${{ matrix.args }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "animepahe-dl-desktop",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "animepahe-dl-desktop",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-progress": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animepahe-dl-desktop",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const NEWLINE = "\n";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+async function main() {
+  const [, , newVersion] = process.argv;
+  if (!newVersion) {
+    console.error("Usage: node scripts/update-version.mjs <new-version>");
+    process.exit(1);
+  }
+
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?$/.test(newVersion)) {
+    console.error(`Invalid version \"${newVersion}\". Use semver format (e.g. 1.2.3 or 1.2.3-beta).`);
+    process.exit(1);
+  }
+
+  const projectRoot = resolve(__dirname, "..");
+
+  await Promise.allSettled([
+    updatePackageJson(projectRoot, newVersion),
+    updatePackageLock(projectRoot, newVersion),
+    updateCargoToml(projectRoot, newVersion),
+    updateTauriConfig(projectRoot, newVersion),
+  ]);
+
+  console.log(`Updated project version to ${newVersion}`);
+}
+
+async function updatePackageJson(root, version) {
+  const path = resolve(root, "package.json");
+  const raw = await readFile(path, "utf8");
+  const json = JSON.parse(raw);
+  json.version = version;
+  await writeFile(path, JSON.stringify(json, null, 2) + NEWLINE, "utf8");
+}
+
+async function updatePackageLock(root, version) {
+  const path = resolve(root, "package-lock.json");
+  if (!existsSync(path)) return;
+  const raw = await readFile(path, "utf8");
+  const json = JSON.parse(raw);
+  json.version = version;
+  if (json.packages && json.packages[""]) {
+    json.packages[""] = {
+      ...json.packages[""],
+      version,
+    };
+  }
+  await writeFile(path, JSON.stringify(json, null, 2) + NEWLINE, "utf8");
+}
+
+async function updateCargoToml(root, version) {
+  const path = resolve(root, "src-tauri/Cargo.toml");
+  const raw = await readFile(path, "utf8");
+  const lines = raw.split(/\r?\n/);
+  let inPackage = false;
+  const updated = lines.map((line) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("[")) {
+      inPackage = trimmed === "[package]";
+      return line;
+    }
+    if (inPackage && trimmed.startsWith("version")) {
+      return line.replace(/version\s*=\s*".*"/, `version = "${version}"`);
+    }
+    return line;
+  });
+  await writeFile(path, updated.join("\n"), "utf8");
+}
+
+async function updateTauriConfig(root, version) {
+  const path = resolve(root, "src-tauri/tauri.conf.json");
+  const raw = await readFile(path, "utf8");
+  const json = JSON.parse(raw);
+  json.version = version;
+  await writeFile(path, JSON.stringify(json, null, 2) + NEWLINE, "utf8");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "animepahe-tauri"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 [build-dependencies]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,7 +19,8 @@ fn main() {
             commands::fetch_episodes,
             commands::preview_sources,
             commands::start_download,
-            commands::check_requirements
+            commands::check_requirements,
+            commands::open_path
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Animepahe DL Desktop",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "identifier": "dev.prateekm.animepahe-dl-desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -940,7 +940,7 @@ function AppContent() {
               </div>
               <div className="grid gap-2 sm:grid-cols-3" data-tour="filters-section">
                 <div className="space-y-1">
-                  <label className="text-xs text-muted-foreground">Resolution</label>
+                  <label className="text-xs text-muted-foreground h-5 flex items-center">Resolution</label>
                   <Select value={resolutionChoice} onValueChange={handleResolutionSelect}>
                     <SelectTrigger>
                       <SelectValue placeholder="Highest available" />
@@ -971,7 +971,7 @@ function AppContent() {
                   )}
                 </div>
                 <div className="space-y-1">
-                  <label className="text-xs text-muted-foreground">Audio</label>
+                  <label className="text-xs text-muted-foreground h-5 flex items-center">Audio</label>
                   <Select
                     value={audio || "any"}
                     onValueChange={(value) => setAudio(value === "any" ? "" : value)}
@@ -992,7 +992,16 @@ function AppContent() {
                   </Select>
                 </div>
                 <div className="space-y-1">
-                  <label className="text-xs text-muted-foreground">Threads</label>
+                  <label className="text-xs text-muted-foreground h-5 flex items-center gap-1">
+                    Threads
+                    <div className="relative group">
+                      <HelpCircle className="h-3.5 w-3.5 text-muted-foreground/80 cursor-help" />
+                      <div className="absolute bottom-full right-0 mb-2 px-3 py-1.5 text-xs text-white bg-gray-900 rounded-md opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-[9999] pointer-events-none w-80 max-w-[90vw] text-left leading-snug">
+                        Controls how many video segments download in parallel. Higher values can finish episodes faster on fast connections but consume more bandwidth and CPU.
+                        <div className="absolute top-full right-3 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-900"></div>
+                      </div>
+                    </div>
+                  </label>
                   <Input
                     type="number"
                     min={2}

--- a/src/components/tour/tourSteps.ts
+++ b/src/components/tour/tourSteps.ts
@@ -29,17 +29,9 @@ export const tourSteps: TourStep[] = [
     id: "episodes-grid",
     title: "Select Episodes",
     content:
-      "Episodes load automatically once you choose an anime. Check the boxes to select specific episodes, or use 'Select all' for the entire series. You can also use the 'Use as spec' button to convert your selection into an episode specification.",
+      "Episodes load automatically once you choose an anime. Use the checkboxes or type patterns like '1,3-5' in the Episodes field—both stay perfectly in sync.",
     target: "[data-tour='episodes-section']",
     placement: "left",
-  },
-  {
-    id: "preview",
-    title: "Preview Sources",
-    content:
-      "Before downloading, you can preview the available video sources. This shows you the different audio/resolution combinations available for your selected episodes.",
-    target: "[data-tour='preview-button']",
-    placement: "right",
   },
   {
     id: "output-folder",

--- a/src/components/tour/tourSteps.ts
+++ b/src/components/tour/tourSteps.ts
@@ -26,18 +26,10 @@ export const tourSteps: TourStep[] = [
     placement: "right",
   },
   {
-    id: "episodes-fetch",
-    title: "Fetch Episode List",
-    content:
-      "Once you've selected an anime, click 'Fetch episodes' to load all available episodes. This will populate the episode grid on the right.",
-    target: "[data-tour='fetch-button']",
-    placement: "top",
-  },
-  {
     id: "episodes-grid",
     title: "Select Episodes",
     content:
-      "Here you can see all available episodes. Check the boxes to select specific episodes, or use 'Select all' for the entire series. You can also use the 'Use as spec' button to convert your selection into an episode specification.",
+      "Episodes load automatically once you choose an anime. Check the boxes to select specific episodes, or use 'Select all' for the entire series. You can also use the 'Use as spec' button to convert your selection into an episode specification.",
     target: "[data-tour='episodes-section']",
     placement: "left",
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface PreviewItem {
 export interface DownloadStatusEvent {
   episode: number;
   status: string;
+  path?: string | null;
 }
 
 export interface DownloadProgressEvent {


### PR DESCRIPTION
## Summary
Fixes the failing release pipeline by replacing the invalid `npmCommand` parameter with the correct `tauriScript` parameter.

## Changes
- Removed `npmCommand: npm` (not supported by tauri-apps/tauri-action@v0)
- Added `tauriScript: npm run tauri` (correct parameter for specifying the Tauri build command)
- Added `includeUpdaterJson: true` for auto-updater support

## Issue
The release pipeline was failing with:
- Error: "Unexpected input(s) 'npmCommand'"
- Build failure on macOS aarch64 target

This fix addresses the parameter issue which should resolve the build failures.