### PR TITLE
Release v0.3.5 - Build Artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
         shell: bash
 
       - name: Build Tauri App
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "animepahe-dl-desktop",
-  "version": "0.3.2",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "animepahe-dl-desktop",
-      "version": "0.3.2",
+      "version": "0.3.5",
       "dependencies": {
         "@infisical/sdk": "^2.0.0",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animepahe-dl-desktop",
-  "version": "0.3.2",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "animepahe-tauri"
-version = "0.3.2"
+version = "0.3.5"
 edition = "2021"
 
 [build-dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Animepahe DL Desktop",
-  "version": "0.3.2",
+  "version": "0.3.5",
   "identifier": "dev.prateekm.animepahe-dl-desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
# Release v0.3.5 - Build Artifacts

This PR triggers the release pipeline to build and upload artifacts for v0.3.5.

## Changes Since Last PR
- Updated `tauri-action` from `@v0` to `@v0.5` for stable release creation
- Draft release already created at: https://github.com/StrangeNoob/animepahe-dl-desktop/releases/tag/app-v0.3.5
- Git tag `app-v0.3.5` already pushed

## Pipeline Will:
- Build for all platforms (macOS Intel/ARM, Windows, Linux)
- Upload artifacts to the existing draft release
- Include updater JSON for auto-updates

Ready to merge and build! 🚀